### PR TITLE
allow string or empty string as resource in download method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export interface HateoasExtended {
   put(resource: object|string, rel: string, payload?: object, axiosOptions?: AxiosRequestConfig, urlPlaceholders?: object):Promise<any>
   delete(resource: object|string, rel: string, params?: object):Promise<any>
   follow(resource: object, rel: string, params?: object, axiosOptions?: AxiosRequestConfig, cachePrefixes?: string[], cacheSuffixes?: string[]):Promise<any>
-  download(resource: object, rel: string, params?: object, axiosOptions?: AxiosRequestConfig, filename?: string):Promise<any>
+  download(resource: object|string, rel: string, params?: object, axiosOptions?: AxiosRequestConfig, filename?: string):Promise<any>
 }
 
 declare function http(config: AxiosRequestConfig): ExtendedAxiosInstance;

--- a/lib/extended.js
+++ b/lib/extended.js
@@ -382,7 +382,12 @@ export default function extended({
 
     async download(resource, rel, params = {}, axiosOptions = {}, filename = 'document.pdf') {
       const dynamicAxiosConfig = await axiosConfigCb()
-
+      if (!resource) {
+        resource = await getRootIndex()
+      } else if (typeof resource.valueOf() === 'string') {
+        resource = await this.get(resource)
+        log(resource, rel)
+      }
       return this.axios.downloadBinary(resource, rel, params, merge(axiosOptions, dynamicAxiosConfig), filename)
     }
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.0--canary.8.4553851871.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jota-one/http-client@1.3.0--canary.8.4553851871.0
  # or 
  yarn add @jota-one/http-client@1.3.0--canary.8.4553851871.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
