### PR TITLE
fix: adapt the cancel mechanism to the AbortController

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelTokenSource} from 'axios'
+import {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 export type cachebusterConfig = {
   callback: Function,
@@ -51,7 +51,7 @@ export interface HateoasExtended {
   cacheDisabled:Boolean,
   axios:HateoasAxiosInstance
   nocache():HateoasExtended
-  generateCanceller():CancelTokenSource
+  generateCanceller():AbortController
   isCancel():Boolean
   clearCache(path?:string, params?:object):void
   resetCache():void

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ export interface HateoasExtended {
   axios:HateoasAxiosInstance
   nocache():HateoasExtended
   generateCanceller():AbortController
-  isCancel():Boolean
+  isCancel(e: object):Boolean
   clearCache(path?:string, params?:object):void
   resetCache():void
   get(hpath: string, params?: object, axiosOptions?: AxiosRequestConfig, suffixes?: string[]):Promise<any>

--- a/lib/extended.js
+++ b/lib/extended.js
@@ -209,10 +209,16 @@ export default function extended({
       const dynamicAxiosConfig = await axiosConfigCb()
       const verb = (axiosOptions.method || 'get').toLowerCase()
       resource = prepareResource(resource, key, verb)
-      let r = await client.followLink(resource, key, params, merge(axiosOptions, dynamicAxiosConfig))
+      const mergedAxiosOptions = merge(axiosOptions, dynamicAxiosConfig)
+
+      // some options can't be merged or they will lose some complex properties
+      if (axiosOptions.signal) {
+        mergedAxiosOptions.signal = axiosOptions.signal
+      }
+      let r = await client.followLink(resource, key, params, mergedAxiosOptions)
 
       for (let proc of responseProcessors) {
-        r = await proc(r, merge(axiosOptions, dynamicAxiosConfig))
+        r = await proc(r, mergedAxiosOptions)
       }
 
       return r
@@ -388,7 +394,13 @@ export default function extended({
         resource = await this.get(resource)
         log(resource, rel)
       }
-      return this.axios.downloadBinary(resource, rel, params, merge(axiosOptions, dynamicAxiosConfig), filename)
+      const mergedAxiosOptions = merge(axiosOptions, dynamicAxiosConfig)
+
+      // some options can't be merged or they will lose some complex properties
+      if (axiosOptions.signal) {
+        mergedAxiosOptions.signal = axiosOptions.signal
+      }
+      return this.axios.downloadBinary(resource, rel, params, mergedAxiosOptions, filename)
     }
   }
 }

--- a/lib/extended.js
+++ b/lib/extended.js
@@ -1,4 +1,3 @@
-import Axios from 'axios'
 import { hateoas } from './http.js'
 import mergician from 'mergician'
 
@@ -218,8 +217,9 @@ export default function extended({
 
       return r
     } catch (err) {
+      console.log('hey!!!', err)
       // if the request was manually cancelled, we throw something different that will be caught later
-      if (Axios.isCancel(err)) {
+      if (err.name === 'AbortError') {
         console.info('Request canceled:', err.message)
         throw Object.assign({}, cancelRequestResult, { cachePath }) // this be used to invalidate the cache
       } else if (err.response) {
@@ -257,7 +257,7 @@ export default function extended({
     },
 
     generateCanceller() {
-      return Axios.CancelToken.source()
+      return new AbortController()
     },
 
     isCancel(e) {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.0--canary.13.5576294907.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jota-one/http-client@1.5.0--canary.13.5576294907.0
  # or 
  yarn add @jota-one/http-client@1.5.0--canary.13.5576294907.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
