### PR TITLE
feat: support for case insensitive http headers

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -87,7 +87,13 @@ function ExtendedAxios(config) {
       }, true)
         .then(response => {
           if (!filename) {
-            const contentDisposition = response.headers['Content-Disposition']
+            const responseHeaders = Object.entries(response.headers).reduce((acc, [name, value]) => {
+              return {
+                ...acc,
+                [name.toLowerCase()]: value
+              }
+            }, {})
+            const contentDisposition = responseHeaders['content-disposition']
             if (contentDisposition) {
               const items = contentDisposition.match(/filename="(.+)"/)
               filename = items && Array.isArray(items) ? items[1] : undefined

--- a/test/http.js
+++ b/test/http.js
@@ -65,6 +65,23 @@ describe('ExtendedAxios', () => {
     expect(result).toBe(filename)
   })
 
+  it('should support any letter case for content-DisPOsiTion', async () => {
+    const client = http()
+
+    // generate a blob content
+    const url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+    const blob = await fetch(url)
+      .then(res => res.blob())
+
+    const filename = 'tépien-pon-c-fussi.png'
+    mock.onGet('https://download.com/myfile').reply(200, blob, {
+      'content-DisPOsiTion': `attachment; filename="${filename}"`
+    })
+
+    const result = await client.downloadBinary('https://download.com/myfile')
+    expect(result).toBe(filename)
+  })
+
   it('should use the provided filename if provided', async () => {
     const client = http()
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.6.1--canary.16.6249816240.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @jota-one/http-client@1.6.1--canary.16.6249816240.0
  # or 
  yarn add @jota-one/http-client@1.6.1--canary.16.6249816240.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
