### PR TITLE
Feat: expose getRootIndex method

### DIFF
--- a/lib/extended.js
+++ b/lib/extended.js
@@ -238,6 +238,7 @@ export default function extended({
   return {
     cacheDisabled: cacheStrategy === 'off',
     axios: client,
+    getRootIndex,
 
     nocache() {
       const newConfig = {


### PR DESCRIPTION
Expose the getRootIndex method from the extended client
